### PR TITLE
add networkx req

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A web app is currently being developed [in another repository](https://github.co
 ```python
 from mofchecker import MOFChecker
 mofchecker = MOFChecker.from_cif(<path_to_cif>)
+# or: MOFChecker(structure=my_pymatgen_structure)
 
 # Test for OMS
 mofchecker.has_oms

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pymatgen~=2020.12.31
 click==7.*
+networkx>=2.5


### PR DESCRIPTION
pymatgen does not seem to lock down the networkx requirement tightly
enough.

also adds note on creating mofchecker directly from pymatgen structure (needed for CSD, since pymatgen complains with default settings)

fix #83 

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation
- [ ] Developer tools
- [ ] Refactoring
- [ ] Test

## Actions (for code changes)

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
