### PR TITLE
feat: thinking on how to reduce the redudancy with check declaration

### DIFF
--- a/mofchecker/__init__.py
+++ b/mofchecker/__init__.py
@@ -77,8 +77,43 @@ DESCRIPTORS = [
 ]
 
 
+class DescriptorMeta(type):
+    def __new__(meta, name, bases, dct):
+        descriptor_properties = []
+        checkers = []
+        for _, value in dct.items():
+            if hasattr(value, "descriptor"):
+                descriptor_properties.append(value)
+            elif hasattr(value, "checker"):
+                checkers.append(value)
+        dct["descriptor_properties"] = descriptor_properties
+        dct["checkers"] = checkers
+
+        return super(DescriptorMeta, meta).__new__(meta, name, bases, dct)
+
+
+def descriptor(function):
+    def inner(*args, **kwargs):
+        # do whatever
+        pass
+
+    inner.descriptor = True
+    return inner
+
+
+def checker(function):
+    def inner(*args, **kwargs):
+        # do whatever
+        pass
+
+    inner.checker = True
+    return inner
+
+
 class MOFChecker:  # pylint:disable=too-many-instance-attributes, too-many-public-methods
     """MOFChecker performs basic sanity checks for MOFs"""
+
+    __metaclass__ = DescriptorMeta
 
     def __init__(self, structure: Union[Structure, IStructure], primitive: bool = True):
         """Class that can perform basic sanity checks for MOF structures
@@ -150,11 +185,6 @@ class MOFChecker:  # pylint:disable=too-many-instance-attributes, too-many-publi
             "no_oms": MOFOMS.from_mofchecker(self),
             "no_false_terminal_oxo": FalseOxoCheck.from_mofchecker(self),
         }
-
-    @property
-    def checks(self):
-        """Get a dictionary of all check classes"""
-        return self._checks
 
     def _set_filename(self, path):
         self._filename = os.path.abspath(path)


### PR DESCRIPTION
<!-- Please tick the breaking change box if you change is a breaking change according to semantic versioning -->

- [X] Breaking change (fix or feature that would cause existing functionality to change)

I'm still not sure what the best design is to reduce redundancy but still allow for easy access via good property names and efficiency (e.g., via caching).

The original motivation for the `check` dictionary was that one could loop over all checks and then get `is_ok`, a `name`, and a `description` and maybe a few more methods.  But in the current way we create the `checks` dictionary it leads to a call to the `graph` property and therefore to graph construction (#144). 
The other design goal was to *not* have an object, e.g a list, *outside* of the class which would need to be updated when we add a new check.

We could solve the latter with a metaclass approach, where we register some properties in a `descriptor` attribute in the class. 
It is still not clear to me how we make a good mapping to the descriptor. ATM, the most feasible approach to me seems to register the check classes also as properties of the mofchecker class which we decorate with something like `check`. This would populate a `checks` list. For the frontend, we could then loop over those checks and get name, description, check result, ....   
Latter should also allow us to add eqeq and zeo++ only to the check if a class variable is set accordingly
