### PR TITLE
speed up lru cache lookup

### DIFF
--- a/mofchecker/__init__.py
+++ b/mofchecker/__init__.py
@@ -10,14 +10,14 @@ import networkx as nx
 from ase import Atoms
 from backports.cached_property import cached_property
 from networkx.algorithms.graph_hashing import weisfeiler_lehman_graph_hash
-from pymatgen.analysis.graphs import ConnectedSite, StructureGraph
-from pymatgen.core.structure import IStructure, Structure
-from pymatgen.io.ase import AseAtomsAdaptor
-from pymatgen.io.cif import CifParser
 
 from mofchecker.checks.local_structure.undercoordinated_rare_earth import (
     UnderCoordinatedRareEarthCheck,
 )
+from mofchecker.utils import IStructure, Structure
+from pymatgen.analysis.graphs import ConnectedSite, StructureGraph
+from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.io.cif import CifParser
 
 from ._version import get_versions
 from .checks.charge_check import ChargeCheck
@@ -138,10 +138,10 @@ class MOFChecker:  # pylint:disable=too-many-instance-attributes, too-many-publi
             "no_overcoordinated_nitrogen": OverCoordinatedNitrogenCheck.from_mofchecker(
                 self
             ),
-            "no_undercoordinated_nitrogen": UnderCoordinatedNitrogenCheck.from_mofchecker(  # pylint: disable=line-too-long
+            "no_undercoordinated_nitrogen": UnderCoordinatedNitrogenCheck.from_mofchecker(
                 self
             ),
-            "no_undercoordinated_rare_earth": UnderCoordinatedRareEarthCheck.from_mofchecker(  # pylint: disable=line-too-long
+            "no_undercoordinated_rare_earth": UnderCoordinatedRareEarthCheck.from_mofchecker(
                 self
             ),
             "no_floating_molecule": FloatingSolventCheck.from_mofchecker(self),

--- a/mofchecker/checks/utils/get_indices.py
+++ b/mofchecker/checks/utils/get_indices.py
@@ -4,9 +4,9 @@ import functools
 from typing import Union
 
 import pymatgen
-from pymatgen.core.structure import IStructure, Structure
 
 from ...definitions import METALS
+from ...utils import IStructure, Structure
 from ..data import _get_vdw_radius
 
 
@@ -84,6 +84,7 @@ def get_rare_earth_indices(structure):
 def get_indices(structure: Union[Structure, IStructure]) -> dict:
     """Get all the relevant indices"""
     if isinstance(structure, Structure):
+        # raise ValueError("noticed regular structure")
         structure = IStructure.from_sites(structure)
     return _get_indices(structure)
 

--- a/mofchecker/symmetry/__init__.py
+++ b/mofchecker/symmetry/__init__.py
@@ -3,7 +3,7 @@
 import functools
 from typing import Union
 
-from pymatgen.core import IStructure, Structure
+from mofchecker.utils import IStructure, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.structure import SymmetrizedStructure
 

--- a/mofchecker/utils.py
+++ b/mofchecker/utils.py
@@ -2,6 +2,9 @@
 """Helper functions for the MOFChecker"""
 import pickle
 
+import pymatgen
+from pymatgen.core.structure import Structure
+
 
 def read_pickle(file):
     """Read a pickle file"""
@@ -49,3 +52,15 @@ def _check_if_ordered(structure):
             raise NotImplementedError(
                 f"Pymatgen currently does not support this {str(site.specie)} element"
             )
+
+
+class IStructure(pymatgen.core.structure.IStructure):
+    """pymatgen IStructure with faster, hash-based equality comparison.
+
+    This dramatically speeds up lookups in the LRU cache.
+    """
+
+    __hash__ = pymatgen.core.structure.IStructure.__hash__
+
+    def __eq__(self, other):
+        return self.__hash__() == other.__hash__()

--- a/mofchecker/utils.py
+++ b/mofchecker/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Helper functions for the MOFChecker"""
+import json
 import pickle
 
 import pymatgen
@@ -55,13 +56,19 @@ def _check_if_ordered(structure):
 
 
 class IStructure(pymatgen.core.structure.IStructure):
-    """pymatgen IStructure with faster, hash-based equality comparison.
+    """pymatgen IStructure with faster equality comparison.
 
-    This dramatically speeds up lookups in the LRU cache.
+    This dramatically speeds up lookups in the LRU cache when an object
+    with the same __hash__ is already in the cache.
     """
 
     __hash__ = pymatgen.core.structure.IStructure.__hash__
 
     def __eq__(self, other):
-        """Only allow hits for same object"""
-        return id(self) == id(other)
+        """Use specific, yet performant hash for equality comparison."""
+        return _istruct_hash(self) == _istruct_hash(other)
+
+
+def _istruct_hash(structure):
+    """Specific, yet performant hash for equality comparison."""
+    return hash(json.dumps(structure.as_dict(), sort_keys=True))

--- a/mofchecker/utils.py
+++ b/mofchecker/utils.py
@@ -2,6 +2,7 @@
 """Helper functions for the MOFChecker"""
 import json
 import pickle
+from functools import cached_property
 
 import pymatgen
 from pymatgen.core.structure import Structure
@@ -66,9 +67,9 @@ class IStructure(pymatgen.core.structure.IStructure):
 
     def __eq__(self, other):
         """Use specific, yet performant hash for equality comparison."""
-        return _istruct_hash(self) == _istruct_hash(other)
+        return self._dict_hash == other._dict_hash
 
-
-def _istruct_hash(structure):
-    """Specific, yet performant hash for equality comparison."""
-    return hash(json.dumps(structure.as_dict(), sort_keys=True))
+    @cached_property
+    def _dict_hash(self):
+        """Specific, yet performant hash."""
+        return hash(json.dumps(self.as_dict(), sort_keys=True))

--- a/mofchecker/utils.py
+++ b/mofchecker/utils.py
@@ -63,4 +63,5 @@ class IStructure(pymatgen.core.structure.IStructure):
     __hash__ = pymatgen.core.structure.IStructure.__hash__
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        """Only allow hits for same object"""
+        return id(self) == id(other)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -3,10 +3,10 @@
 import os
 
 import pytest
-from pymatgen.core import Structure
-from pymatgen.transformations.standard_transformations import RotationTransformation
 
 from mofchecker import MOFChecker
+from pymatgen.core import Structure
+from pymatgen.transformations.standard_transformations import RotationTransformation
 
 from .conftest import THIS_DIR
 
@@ -85,8 +85,11 @@ def test_graph_hash_robustness():  # pylint: disable=too-many-locals
 
 
 @pytest.mark.past_issue
-def test_graph_hash_robustness_past_issue():
-    """Test the hash on past issues"""
+def test_graph_hash_false_positives():
+    """Test the hash on past issues of false positives.
+
+    Cases where different structures gave the same hash.
+    """
     # issue 130
     cof_18141N2 = MOFChecker.from_cif(  # pylint: disable=invalid-name
         os.path.join(THIS_DIR, "test_files", "18141N2.cif")
@@ -95,18 +98,6 @@ def test_graph_hash_robustness_past_issue():
         os.path.join(THIS_DIR, "test_files", "20211N2.cif")
     )
     assert cof_18141N2.graph_hash != cof_20211N2.graph_hash
-
-    # issue 107
-    oriwet = MOFChecker(
-        Structure.from_file(os.path.join(THIS_DIR, "test_files", "ORIWET.cif"))
-    )
-
-    coknun = MOFChecker(
-        Structure.from_file(os.path.join(THIS_DIR, "test_files", "COKNUN.cif"))
-    )
-
-    assert oriwet.graph_hash == coknun.graph_hash
-    assert oriwet.scaffold_hash == coknun.scaffold_hash
 
     # # Daniele's report
     mmpf7 = MOFChecker(
@@ -118,3 +109,27 @@ def test_graph_hash_robustness_past_issue():
 
     assert mmpf7.graph_hash != mmpf8.graph_hash
     assert mmpf7.scaffold_hash != mmpf8.scaffold_hash
+
+    # ZIF3/4
+    # zif3 = MOFChecker.from_cif(os.path.join(THIS_DIR, "test_files", "ZIF-3.cif"))
+    # zif4 = MOFChecker.from_cif(os.path.join(THIS_DIR, "test_files", "ZIF-4.cif"))
+    # assert zif3.graph_hash != zif4.graph_hash
+
+
+@pytest.mark.past_issue
+def test_graph_hash_false_negatives():
+    """Test the hash on past issues of false negatives.
+
+    Cases of structures that should match but the graph hash did not.
+    """
+    # issue 107: Mn-MOF-74: ASR ORIWET and COKNUN… give different hash
+    oriwet = MOFChecker(
+        Structure.from_file(os.path.join(THIS_DIR, "test_files", "ORIWET.cif"))
+    )
+
+    coknun = MOFChecker(
+        Structure.from_file(os.path.join(THIS_DIR, "test_files", "COKNUN.cif"))
+    )
+
+    assert oriwet.graph_hash == coknun.graph_hash
+    assert oriwet.scaffold_hash == coknun.scaffold_hash


### PR DESCRIPTION
The LRU cache is implemented using python dictionaries, where the
function arguments become the "key" for the lookup.
In this lookup, python dictionaries use the `__eq__` method to compare
keys (not the `__hash__` method).

For `pymatgen.core.structure.IStructure`, the `__eq__` method is very
slow (it checks whether coordinates agree within a given threshold).

The dictionary lookup has a trick: if one looks up by the same object in memory,
then lookup is fast and `__eq__` is not called.
This is what happens when you run

```python
mofchecker = MOFChecker.from_cif('tests/structures/str_m1_o12004_MTW.cif')
```
once (takes ~20s, which is also way too slow but one step at a time).

However, when you run it the next time
```python
mofchecker = MOFChecker.from_cif('tests/structures/str_m1_o12004_MTW.cif')
```
it now takes ~90s because there are 12 lookups in the LRU cache, each of which takes several seconds.

Here we subclass `IStructure`, overwriting the equality check to make
cache lookups performant.
Unfortunately, this is also not a satisfactory solution since the
default hash implemented by `IStructure` is very minimal: it just checks
whether the composition is the same.
I.e. if you are running two structures after another that have the same
composition but different indices you would now get a wrong result.

One could try improving the `IStructure` hash but, probably the
indices should rather be cached on a `MOFChecker` instance, not globally.
Since one anyhow creates new instances for new structures that would
solve the cache invalidation issue automatically - the only problem is
that the new code layout with the separate checks makes moving the cache
to the `MOFChecker` a bit complicated.

Any thoughts @kjappelbaum?

<!-- Please tick the breaking change box if you change is a breaking change according to semantic versioning -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
