### PR TITLE
bump minimal pymatgen version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=pytest_runner,
     install_requires=[
-        "pymatgen<2023",
+        "pymatgen>=2022.0.12,<2023",
         "click",
         "networkx>=2.5",
         "backports.cached-property",


### PR DESCRIPTION
On [Jul 30th 2020](https://github.com/materialsproject/pymatgen/commit/684a140d152daf43590b7c19b1718b0cb31c12fd) (v2020.0.0, v2020.8.3) a major bug was introduced into the `get_neighbors` function of pymatgen that resulted in atoms with negative coordinates not being properly wrapped back into the unit cell (see [issue](https://github.com/materialsproject/pymatgen/issues/2226))

This bug was fixed on [Aug 25th 2021](https://github.com/materialsproject/pymatgen/commit/b21f73fc6439d4c8ab43cf557f5c7e7dd95f460a) (v2022.0.12), i.e. more than one year later.

This might solve issues with false negatives (structures that get the same hash but shouldn't) but won't solve issues with false positives.

<!-- Please tick the breaking change box if you change is a breaking change according to semantic versioning -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
