### PR TITLE
fix: negate has_atomic_overlaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mofchecker = MOFChecker.from_cif(<path_to_cif>)
 mofchecker.has_oms
 
 # Test for clashing atoms
-mofchecker.has_overlapping_atoms
+mofchecker.has_atomic_overlaps
 
 # Run basic checks on a list of cif paths (sample_structures)
 results = []

--- a/mofchecker/__init__.py
+++ b/mofchecker/__init__.py
@@ -214,7 +214,7 @@ class MOFChecker:  # pylint:disable=too-many-instance-attributes, too-many-publi
     @property
     def has_atomic_overlaps(self) -> bool:
         """Check if there are any overlaps in the structure"""
-        return self.checks["no_atomic_overlaps"].is_ok
+        return not self.checks["no_atomic_overlaps"].is_ok
 
     @property
     def name(self) -> str:

--- a/mofchecker/checks/local_structure/overlapping_atoms.py
+++ b/mofchecker/checks/local_structure/overlapping_atoms.py
@@ -3,8 +3,9 @@
 import warnings
 
 import numpy as np
-from pymatgen.core import Structure
 from scipy import sparse
+
+from pymatgen.core import Structure
 
 from ..check_base import AbstractIndexCheck
 from ..data import _get_covalent_radius
@@ -28,7 +29,7 @@ class AtomicOverlapCheck(AbstractIndexCheck):
     @property
     def description(self):
         return (
-            "Checks if there are atomic overlaps, based on dist < min(covr 1, covr 2)"
+            "True, if there are no atomic overlaps, based on dist < min(covr 1, covr 2)"
         )
 
 

--- a/mofchecker/definitions.py
+++ b/mofchecker/definitions.py
@@ -27,7 +27,7 @@ CHECK_DESCRIPTIONS = {
     "has_oms": "Uses heuristics of order parameter to estimate if there is an uncordinated metal site",
     "has_carbon": "Checks if there is any carbon in the structure",
     "has_hydrogen": "Checks of there is any hydrogen in the structure",
-    "has_atomic_overlaps": "Checks if there are atomic overlaps in the structure (estimated based on the adjacency matrix)",
+    "has_atomic_overlaps": "Checks if there are atomic overlaps in the structure (based on adjacency matrix)",
     "has_overcoordinated_c": "Checks if there is any carbon number with coordination number > 4",
     "has_overcoordinated_n": "Checks if there is any nitrogen with coordination number > 4",
     "has_overcoordinated_h": "Checks if there is any carbon with coordination number > 1",

--- a/tests/test_mofchecker.py
+++ b/tests/test_mofchecker.py
@@ -5,9 +5,9 @@ import os
 
 import pytest
 from ase.io import read
-from pymatgen.core import Structure
 
 from mofchecker import MOFChecker
+from pymatgen.core import Structure
 
 from .conftest import THIS_DIR
 
@@ -50,6 +50,13 @@ def test_overvalent_h():
         os.path.join(THIS_DIR, "test_files", "XIGFOJ_manual.cif")
     )
     assert not mofchecker.has_overvalent_h
+
+
+def test_overlaps():
+    mofchecker = MOFChecker.from_cif(
+        os.path.join(THIS_DIR, "test_files", "overvalent_h.cif")
+    )
+    assert not mofchecker.has_atomic_overlaps
 
 
 def test_overvalent_c(get_overvalent_c_structures):


### PR DESCRIPTION
fixes #171 

`MOFChecker.has_atomic_overlaps` returned `True` when there were *no*
atomic overlaps in the structure.

Fixing this and adding a test.

<!-- Please tick the breaking change box if you change is a breaking change according to semantic versioning -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
